### PR TITLE
power: Simplify display_boost checks

### DIFF
--- a/power/power-8084.c
+++ b/power/power-8084.c
@@ -48,7 +48,6 @@
 #include "power-common.h"
 
 static int first_display_off_hint;
-extern int display_boost;
 
 int get_number_of_profiles() {
     return 3;
@@ -132,14 +131,12 @@ int set_interactive_override(struct power_module *module, int on)
          * We need to be able to identify the first display off hint
          * and release the current lock holder
          */
-        if (display_boost) {
-            if (!first_display_off_hint) {
-                undo_initial_hint_action();
-                first_display_off_hint = 1;
-            }
-            /* used for all subsequent toggles to the display */
-            undo_hint_action(DISPLAY_STATE_HINT_ID_2);
+        if (!first_display_off_hint) {
+            undo_initial_hint_action();
+            first_display_off_hint = 1;
         }
+        /* Used for all subsequent toggles to the display */
+        undo_hint_action(DISPLAY_STATE_HINT_ID_2);
 
         if ((strncmp(governor, ONDEMAND_GOVERNOR, strlen(ONDEMAND_GOVERNOR)) == 0) &&
                 (strlen(governor) == strlen(ONDEMAND_GOVERNOR))) {
@@ -152,11 +149,9 @@ int set_interactive_override(struct power_module *module, int on)
         }
     } else {
         /* Display on */
-        if (display_boost) {
-            int resource_values2[] = {CPUS_ONLINE_MIN_2};
-            perform_hint_action(DISPLAY_STATE_HINT_ID_2,
-                    resource_values2, ARRAY_SIZE(resource_values2));
-        }
+        int resource_values2[] = { CPUS_ONLINE_MIN_2 };
+        perform_hint_action(DISPLAY_STATE_HINT_ID_2,
+                resource_values2, ARRAY_SIZE(resource_values2));
 
         if ((strncmp(governor, ONDEMAND_GOVERNOR, strlen(ONDEMAND_GOVERNOR)) == 0) &&
                 (strlen(governor) == strlen(ONDEMAND_GOVERNOR))) {

--- a/power/power-8916.c
+++ b/power/power-8916.c
@@ -58,7 +58,6 @@ char scaling_min_freq[4][80] ={
     "sys/devices/system/cpu/cpu3/cpufreq/scaling_min_freq"
 };
 
-int display_boost;
 static int slack_node_rw_failed = 0;
 
 int get_number_of_profiles() {

--- a/power/power-8974.c
+++ b/power/power-8974.c
@@ -49,12 +49,34 @@
 #include "power-common.h"
 
 static int first_display_off_hint;
-extern int display_boost;
 
 static int current_power_profile = PROFILE_BALANCED;
 
 int get_number_of_profiles() {
     return 5;
+}
+
+/**
+ * If target is 8974pro:
+ *     return 1
+ * else:
+ *     return 0
+ */
+static int is_target_8974pro(void)
+{
+    static int is_8974pro = -1;
+    int soc_id;
+
+    if (is_8974pro >= 0)
+        return is_8974pro;
+
+    soc_id = get_soc_id();
+    if (soc_id == 194 || (soc_id >= 208 && soc_id <= 218))
+        is_8974pro = 1;
+    else
+        is_8974pro = 0;
+
+    return is_8974pro;
 }
 
 static void set_power_profile(int profile) {
@@ -193,7 +215,7 @@ int set_interactive_override(struct power_module *module __unused, int on)
          * We need to be able to identify the first display off hint
          * and release the current lock holder
          */
-        if (display_boost) {
+        if (is_target_8974pro()) {
             if (!first_display_off_hint) {
                 undo_initial_hint_action();
                 first_display_off_hint = 1;
@@ -213,7 +235,7 @@ int set_interactive_override(struct power_module *module __unused, int on)
         }
     } else {
         /* Display on */
-        if (display_boost) {
+        if (is_target_8974pro()) {
             int resource_values2[] = {CPUS_ONLINE_MIN_2};
             perform_hint_action(DISPLAY_STATE_HINT_ID_2,
                     resource_values2, ARRAY_SIZE(resource_values2));

--- a/power/power.c
+++ b/power/power.c
@@ -57,7 +57,6 @@ static int saved_mpdecision_slack_max = -1;
 static int saved_mpdecision_slack_min = -1;
 static int slack_node_rw_failed = 0;
 static int display_hint_sent;
-int display_boost;
 
 static struct hw_module_methods_t power_module_methods = {
     .open = NULL,
@@ -67,14 +66,7 @@ static pthread_mutex_t hint_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static void power_init(__attribute__((unused))struct power_module *module)
 {
-    int soc_id;
-
     ALOGI("QCOM power HAL initing.");
-
-    soc_id = get_soc_id();
-    if (soc_id == 178 || soc_id == 194 ||
-            (soc_id >= 208 && soc_id <= 218))
-        display_boost = 1;
 }
 
 static void process_video_decode_hint(void *metadata)


### PR DESCRIPTION
 - Remove 8084 check as all 8084s make use of the display boost
 - Convert the display_boost check to an soc_id check for 8974pro
 - Move display_boost (now soc_id) check to 8974's HAL

Change-Id: I237b9108e666f4cb0051d1c1bb22453d55ffcdc7
(cherry picked from commit ba9d9d97f4c5ab8f80fb452950d542237190d8d4)